### PR TITLE
make suite set up async

### DIFF
--- a/check.go
+++ b/check.go
@@ -643,8 +643,8 @@ func (runner *suiteRunner) asyncRun(wg *sync.WaitGroup, notifyRunningSuitesCh ch
 	}
 
 	wg.Add(1)
-	c := runner.runFixture(runner.setUpSuite, "", nil)
 	go func() {
+		c := runner.runFixture(runner.setUpSuite, "", nil)
 		defer wg.Done()
 		<-notifyRunningSuitesCh
 		runner.doRun(c)


### PR DESCRIPTION
move `setUpSuite` into go routine so that we can run it async.

this is useful in the `-check.p ture` mode when setUpSuite need to acquire limited shared resources, so some testSuite's setup will block all the tests from running.

example: in the [tidb/session](https://github.com/pingcap/tidb/blob/master/session/session_test.go#L139-L154) test, when runnint in `-with-tikv` mode, there are limited tikv store to acquire, thus all the tests would be block in `setUpSuite` if we run with `-check.p ture`

related [tidb pr](https://github.com/pingcap/tidb/pull/14709)