### PR TITLE
LICENSE: move the LICENSE file back to the original place

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,18 @@
 Gocheck - A rich testing framework for Go
- 
+
 Copyright (c) 2010-2013 Gustavo Niemeyer <gustavo@niemeyer.net>
+Copyright (c) 2015-2021 PingCAP, Inc.
 
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met: 
+modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution. 
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED


### PR DESCRIPTION
pkg.go.dev [requires a LICENSE file](https://pkg.go.dev/license-policy) in order to view the docs.

However, in #1 the original LICENSE file is renamed to `check.v1_license` **without a proper replacement**. This makes the module missing on pkg.go.dev:

> https://pkg.go.dev/github.com/pingcap/check@v0.0.0-20200212061837-5e12011dc712

Since godoc.org is now a perma-redirect to pkg.go.dev, we must need the LICENSE file in place.